### PR TITLE
Fix: 'regions' doesn't work

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ var validate = function(path, props, $this, dtype) {
             }
 
             if ( props.hasOwnProperty('region') && (typeof props.region === 'string') ) {
-                if (dtype === 'entries') {
+                if (dtype === 'entries' || dtype === null) {
                     path += '/regions=' + encodeURIComponent(props.region.toString());    
                 } else {
                     path += ';regions=' + encodeURIComponent(props.region.toString());    


### PR DESCRIPTION
Hi, When I tried to set `region=us` in `props` for `find` method I've got the unexpected result, but after I have changed this small piece of code all is OK.
@SleepyBandit Please, check this.