### PR TITLE
Version number bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxford-dictionary",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "A nodeJS wrapper for using the oxforddictionary.com REST API.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Forgot to do this in my initial pull request.

Bumped to 1.5.0 rather than 2.0.0 because none of the changes here break usage for people using this library.

Could you publish this on npm after accepting the pull request? Thanks :)